### PR TITLE
Check if content is empty or not before using DOMDocument

### DIFF
--- a/bb-lazy-load.php
+++ b/bb-lazy-load.php
@@ -113,6 +113,10 @@ function bbll_settings_html(){
 
 function bbll_builder_render_content($content){
 
+  if(empty($content)){
+    return $content;
+  }
+  
   $doc = new DOMDocument();
   $doc->loadHTML($content);
 


### PR DESCRIPTION
PHP was throwing a warning for an empty string input when DOMDocument was trying to loadHTML.